### PR TITLE
Remove broken ck declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function find(path, extensions, cb) {
 
 			path = join(dir, base + ext);
 
-			ck = check(path, function (err, stat) {
+			check(path, function (err, stat) {
 				found = stat && !stat.isDirectory();
 
 				return next(!found)


### PR DESCRIPTION
The variable assignment to `ck` on line 48 was unnecessary and since there was no definition for `ck` it was causing Node to crash when running in strict mode.

(In case you're wondering, I'm using koa-handlebars which depends on this module, and koa uses lots of ES6 features including `let` which requires strict mode.)
